### PR TITLE
Fix invalid text-align property

### DIFF
--- a/src/components/text/Article.js
+++ b/src/components/text/Article.js
@@ -10,7 +10,7 @@ const Article = (props) => {
   const defaultStyles = {
     padding: 10,
     border: testLayout && "2px solid red",
-    textAlign: 'flex-start',
+    textAlign: 'left',
     ...style,
   };
 


### PR DESCRIPTION
## Summary
- fix incorrect text-align style in `Article` component

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68409c76fe408321a4e5a0bbe7d9c5c9